### PR TITLE
Apply the method to window explicitely

### DIFF
--- a/src/respond.js
+++ b/src/respond.js
@@ -350,4 +350,4 @@
 	else if( w.attachEvent ){
 		w.attachEvent( "onresize", callMedia );
 	}
-})(this);
+})(window);


### PR DESCRIPTION
To include respond.js using webpack, it is required to have the scope specified explicitly to window (instead of this), since it is enclosed in an import function where this is not window.
