### PR TITLE
Apply the method to window explicitely

### DIFF
--- a/src/matchmedia.polyfill.js
+++ b/src/matchmedia.polyfill.js
@@ -33,4 +33,4 @@
 		};
 
 	}( w.document ));
-}( this ));
+}( window ));


### PR DESCRIPTION
To include respond.js using webpack, it is required to have the scope specified explicitly to window (instead of this), since it is enclosed in an import function where this is not window.
